### PR TITLE
feat!: allow major version update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ version_toml = [
 ]
 changelog_file = "CHANGELOG.md"
 build_command = "pip install poetry && poetry build"
-major_on_zero = false
+major_on_zero = true
 prerelease = true
 prerelease_tag = "rc"
 


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change sets the `major_on_zero` option to true, which will allow major version increments even when the current version is 0.x.x.