### PR TITLE
fix: manually update starting version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,6 +66,7 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v8.7.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          force: true
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The healthsciencecalculator.py package is released under the MIT license to prom
 
 ## Contributors
 
-Forgive Agbesi
-Hala Arar
-Jiayi Li
+Forgive Agbesi,
+Hala Arar,
+Jiayi Li,
 Tengwei Wang

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,15 @@ sphinx-rtd-theme = "^3.0.2"
 python-semantic-release = "^9.17.0"
 
 [tool.semantic_release]
-version_toml = [
-    "pyproject.toml:tool.poetry.version",
-]
+version_variables = ["pyproject.toml:version"]
+version_toml = ["pyproject.toml:tool.poetry.version"]
 changelog_file = "CHANGELOG.md"
 build_command = "pip install poetry && poetry build"
-major_on_zero = true
+major_on_zero = false
 prerelease = true
 prerelease_tag = "rc"
+branch = "main"
+starting_version = "1.1.0"
 
 [tool.semantic_release.branches.main]
 match = "main"


### PR DESCRIPTION
This pull request includes several important changes to the CI/CD workflow, the project configuration, and the documentation. The changes improve the release process, update the versioning configuration, and correct the formatting in the contributors' list.

### CI/CD Workflow Improvements:
* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R69): Added the `force: true` parameter to the `python-semantic-release` action to ensure that the release process is enforced.

### Project Configuration Updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L32-R40): Updated the versioning configuration by changing `version_variables` and adding `branch` and `starting_version` parameters. Also set `major_on_zero` to `false`.

### Documentation Formatting:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L238-R240): Corrected the formatting of the contributors' list by adding commas after each name.